### PR TITLE
Add records to explicitly set pump calculation method in timed mode

### DIFF
--- a/jsco4180Sup/jsco4180.db
+++ b/jsco4180Sup/jsco4180.db
@@ -650,6 +650,47 @@ record(ai, "$(P)TIME")
     field(SDIS, "$(P)DISABLE")
 }
 
+record(bo, "$(P)TIME:CALC:SP")
+{
+    field(DESC, "Pump calculation mode set point")
+    field(PINI, "YES")
+    field(VAL, "0")
+    
+    field(ZNAM, "Time")
+    field(ONAM, "Volume")
+    
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:_COMP:SP")
+    field(SDIS, "$(P)DISABLE")
+    
+    field(FLNK, "$(P)TIME:RUN:_TOG")
+}
+
+alias("$(P)TIME:CALC:SP", "$(P)SIM:TIME:CALC:SP")
+
+alias("$(P)TIME:CALC:SP", "$(P)TIME:CALC:SP:RBV")
+
+alias("$(P)TIME:CALC:SP", "$(P)TIME:CALC")
+
+
+record(calcout, "$(P)TIME:RUN:_TOG")
+{
+    field(DESC, "Toggle time control")
+    field(INPA, "$(P)TIME:CALC:SP")
+    field(CALC, "A")
+    field(OUT, "$(P)TIME:RUN:SP.DISP PP")
+    
+    field(FLNK, "$(P)TIME:VOL:_TOG")
+}
+
+record(calcout, "$(P)TIME:VOL:_TOG")
+{
+    field(DESC, "Toggle volume control")
+    field(INPA, "$(P)TIME:CALC:SP")
+    field(CALC, "A ? 0 : 1")
+    field(OUT, "$(P)TIME:VOL:SP.DISP PP")
+}
+
 record(mbbi, "$(P)TIME:MODE") 
 {
     field(DESC, "Mode of time checking")


### PR DESCRIPTION
Added a record for selecting which calculation method is used for setting timed run parameters, i.e. either volume or run duration.

This is done by enabling/disabling external writes to `TIME:RUN:SP` and `TIME:VOL:SP` respectively based on the value of `TIME:CALC:SP`.

Ticket:
https://github.com/ISISComputingGroup/IBEX/issues/4029

Related PRs:
https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/pull/189
https://github.com/ISISComputingGroup/ibex_gui/pull/891
